### PR TITLE
feat: Pyion can now optionally return bundle headers when receiving

### DIFF
--- a/pyion/_bp.c
+++ b/pyion/_bp.c
@@ -430,8 +430,6 @@ static PyObject *pyion_bp_receive(PyObject *self, PyObject *args)
         ret_payload_metadata = PyDict_New();
 
         // Add some key-value pairs to the dictionary (modify as needed)
-        // TODO: Make sure that data is copied from buffer, do not delete data buffer or use pointer/reference
-        // TODO: Py_BuildValue may already do copying, but make sure this is the case 
         PyDict_SetItemString(ret_payload_metadata, "timeToLive", PyLong_FromLong(msg.timeToLive));
         PyDict_SetItemString(ret_payload_metadata, "bundleSourceEid", Py_BuildValue("s", msg.bundleSourceEid));
         PyDict_SetItemString(ret_payload_metadata, "metadata", Py_BuildValue("y#", msg.metadata, (Py_ssize_t)msg.metadataLen));

--- a/pyion/base_bp.c
+++ b/pyion/base_bp.c
@@ -157,6 +157,18 @@ int help_receive_data(BpSapState *state, BpDelivery *dlv, BpRx *msg)
     msg->len = len;
     msg->do_malloc = do_malloc;
 
+    
+    // Add headers
+    msg->bundleSourceEid = malloc(strlen(dlv->bundleSourceEid) + 1);
+    strcpy(msg->bundleSourceEid, dlv->bundleSourceEid);
+    msg->bundleCreationTime.msec = dlv->bundleCreationTime.msec;
+    msg->bundleCreationTime.count = dlv->bundleCreationTime.count;
+	msg->timeToLive = dlv->timeToLive;
+	msg->metadataType = dlv->metadataType;
+	msg->metadataLen = dlv->metadataLen;
+	memcpy(msg->metadata, dlv->metadata,
+			BP_MAX_METADATA_LEN);
+
     // Close transaction and/or handle error while getting the payload
     if (sdr_end_xn(sdr) < 0 || len < 0)
     {

--- a/pyion/base_bp.h
+++ b/pyion/base_bp.h
@@ -44,6 +44,12 @@ typedef struct
     int do_malloc;
     char payload_prealloc[MAX_PREALLOC_BUFFER];
     char *payload; // If we must malloc, remember to set do_malloc to 1         
+    char *bundleSourceEid;
+	BpTimestamp	bundleCreationTime;
+	unsigned int timeToLive;
+    unsigned char	metadataType;	/*	See RFC 6258.		*/
+	unsigned char	metadataLen;
+	unsigned char	metadata[BP_MAX_METADATA_LEN];
 } BpRx;
 
 /**


### PR DESCRIPTION
A new optional parameter for `bp_receive` called `return_headers` has been created. This param takes a boolean value where if set to True, the function call will return a tuple where the first value is the bundle payload and the second is the bundle headers. 

The current behavior is to return only the bundle payload. This param is set to False by default so that any existing code will not be broken by this change. 